### PR TITLE
feat: 시나리오 1-tier-ec2 테라폼 개발

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -10,6 +10,15 @@ projects:
       enabled: true
     apply_requirements: []
     workflow: id
+  - name: 00.1-tier-ec2
+    dir: terraform/scenario/00.1-tier-ec2
+    workspace: default
+    terraform_version: 1.10.5
+    autoplan:
+      when_modified: ["*.tf", "terraform.tfvars"]
+      enabled: true
+    apply_requirements: []
+    workflow: id
 #### Workflows #####
 workflows:
   # id

--- a/terraform/scenario/00.1-tier-ec2/.terraform.lock.hcl
+++ b/terraform/scenario/00.1-tier-ec2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.87.0"
+  constraints = ">= 3.29.0, >= 4.66.0, >= 5.46.0, >= 5.79.0"
+  hashes = [
+    "h1:IYq3by7O/eJuXzJwOF920z2nZEkw08PkDFdw2xkyhrs=",
+    "zh:017f237466875c919330b9e214fb33af14fffbff830d3755e8976d8fa3c963c2",
+    "zh:0776d1e60aa93c85ecbb01144aed2789c8e180bb0f1c811a0aba17ca7247b26c",
+    "zh:0dfa5c6cfb3724494fdc73f7d042515e88a20da8968959f48b3ec0b937bd8c8f",
+    "zh:1707a5ead36a7980cb3f83e8b69a67a14ae725bfc990ddfcc209b59400b57b04",
+    "zh:1c71f54fdd6adcbe547d6577dbb843d72a30fef0ab882d0afbeb8a7b348bc442",
+    "zh:3563c850a29790957ec3f4d3ba203bfa2e084ac7319035b3f43b91f818a2c9b4",
+    "zh:520bf6cef53785a92226651d5bebacbbf9314bdbc3211d0bf0903bce4e45149d",
+    "zh:56f9778575830f6e5c23462c2eccbf2c9afaddb00a69275fcfb33cd1a6d17f4d",
+    "zh:73e381cb0b1e76d471d7b0952f3d2a80350b507d15bda9b7041ea69077e3b5b5",
+    "zh:7da74b48f8fa088be758a92407980400cb4b039a8d9ba3c108907e4055e9ad6f",
+    "zh:8dacfa9623ba2e0197fe7db6faaaa0820a3b91fe00ba9e5d8a646340522bc8dd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c2ebd21d697e1a611fe201788dc9e1678949a088afc85d4589563bca484d835",
+    "zh:ac5d0bbf36f9a6cedbfb63993f6baf0aabdaf21c8d7fc3b1e69ba8cbf344b5f3",
+    "zh:c2329644179f78a0458b6cf2dd5eaadca4c610fc3577a1b50620544d92df13e8",
+  ]
+}

--- a/terraform/scenario/00.1-tier-ec2/README.md
+++ b/terraform/scenario/00.1-tier-ec2/README.md
@@ -1,0 +1,30 @@
+# AWS ec2 서버 구성
+
+1. SSM을 이용해서 터미널 접속
+2. VPC를 구성하고 퍼블릭/프라이빗 서브넷을 구성한다. (인터넷게이트웨이, 라우팅테이블, NAT 인스턴스 구현)
+
+## 네트워크 토폴리지
+
+- VPC CIDR : 10.0.0.0/16
+
+![1](https://github.com/int128/terraform-aws-nat-instance/raw/master/diagram.svg)
+
+## 모듈
+
+- vpc : [terraform-aws-modules/vpc/aws](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest)
+- ec2 : [terraform-aws-modules/ec2](https://registry.terraform.io/modules/terraform-aws-modules/ec2-instance/aws/latest)
+- NAT인스턴스 : [int128/nat-instance/aws](https://github.com/int128/terraform-aws-nat-instance/tree/master?tab=readme-ov-file)
+- 보안그룹(Security Group) : [terraform-aws-modules/security-group/aws](https://registry.terraform.io/modules/terraform-aws-modules/security-group/aws/latest)
+
+## SSM 특징/장점
+
+✅ 인바운드 포트를 열거나 SSH 키를 관리할 필요 없이 관리형 인스턴스에 안전하게 연결한다.
+✅ Bastion host 나 Key pair 가 필요 없다.
+✅ HTTPS 프로토콜을 사용하여 접속이 가능하다. (SSH가 아님)
+✅ 선택한 목적 또는 활동에 따라 AWS 리소스를 그룹화하여 중앙 집중식 관리가 가능하다.
+
+### 세션관리자 bash쉘로 열기
+
+AWS Systems Manager >> 세션 관리자 >> 기본 설정 >> Shell profiles >> Linux shell profile
+
+![2](https://blog.kakaocdn.net/dn/cVgYWw/btrJ70pm8kc/qoKDmlZEDGDsfVsQl8jWuk/img.png)

--- a/terraform/scenario/00.1-tier-ec2/backend.tf
+++ b/terraform/scenario/00.1-tier-ec2/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  # backend "s3" {
+  #   region  = "ap-northeast-2"
+  #   bucket  = "cheonkyu-atlantics-tfstate"
+  #   key     = "provising/terraform/scenario/00.server/terraform.tfstate"
+  #   profile = "default"
+  # }
+}

--- a/terraform/scenario/00.1-tier-ec2/main.tf
+++ b/terraform/scenario/00.1-tier-ec2/main.tf
@@ -1,0 +1,137 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  name   = var.name
+  region = var.region
+
+  vpc_cidr = var.vpc_cidr
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  tags = {
+    Terraform   = true
+    environment = var.environment
+  }
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  azs    = local.azs
+
+  name = local.name
+  cidr = local.vpc_cidr
+  # private은 NAT G/W를 통해 외부 요청이 가능한 서브넷
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  # intra는 격리된 네트워크
+  # intra_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  public_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 4)]
+
+  create_database_subnet_group  = false
+  manage_default_network_acl    = false
+  manage_default_route_table    = false
+  manage_default_security_group = false
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  # NAT instance를 쓴다
+  enable_nat_gateway = false
+  single_nat_gateway = false
+
+  # VPC flow
+  # vpc_flow_log_iam_role_name            = "${local.name}-role"
+  # vpc_flow_log_iam_role_use_name_prefix = true
+  # enable_flow_log                       = true
+  # create_flow_log_cloudwatch_log_group  = false
+  # create_flow_log_cloudwatch_iam_role   = false
+  # flow_log_max_aggregation_interval     = 600
+
+  tags = local.tags
+}
+
+module "nat" {
+  source = "int128/nat-instance/aws"
+
+  name                        = var.name # "nat-instance-${name}" prefix가 있음
+  vpc_id                      = module.vpc.vpc_id
+  public_subnet               = module.vpc.public_subnets[0]
+  private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  private_route_table_ids     = module.vpc.private_route_table_ids
+}
+
+resource "aws_eip" "nat" {
+  network_interface = module.nat.eni_id
+  tags              = local.tags
+}
+
+module "ec2" {
+  source = "terraform-aws-modules/ec2-instance/aws"
+
+  name                        = "single-instance"
+  ami                         = "ami-0fa42ed59eb46290d"
+  instance_type               = "t2.micro"
+  monitoring                  = true
+  subnet_id                   = element(module.vpc.private_subnets, 0)
+  create_spot_instance        = true
+  create_iam_instance_profile = true
+  iam_role_description        = "IAM role for EC2 instance"
+  iam_role_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  }
+  vpc_security_group_ids = [module.sg_ssm.security_group_id]
+  user_data              = <<EOF
+    #!/bin/bash
+    sleep 20s
+    systemctl restart amazon-ssm-agent.service
+    EOF
+  tags                   = local.tags
+}
+
+module "vpc_endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 5.0"
+
+  vpc_id = module.vpc.vpc_id
+  # security_group_ids = [module.sg_ssm.security_group_id]
+
+  endpoints = { for service in toset(["ssm", "ssmmessages", "ec2messages"]) :
+    replace(service, ".", "_") =>
+    {
+      service             = service
+      subnet_ids          = module.vpc.private_subnets
+      private_dns_enabled = false
+      tags                = { Name = "${local.name}-${service}" }
+    }
+  }
+
+  create_security_group      = true
+  security_group_name_prefix = "${local.name}-vpc-endpoints"
+  security_group_description = "VPC endpoint security group"
+  security_group_rules = {
+    ingress_https = {
+      description = "HTTPS from subnets"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    }
+  }
+
+  tags = local.tags
+}
+
+module "sg_ssm" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = "${local.name}-ssm-ec2"
+  description = "Security Group for EC2 Instance SSM"
+
+  vpc_id = module.vpc.vpc_id
+
+  egress_with_cidr_blocks = [
+    {
+      rule        = "https-443-tcp"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+
+  tags = local.tags
+}
+

--- a/terraform/scenario/00.1-tier-ec2/outputs.tf
+++ b/terraform/scenario/00.1-tier-ec2/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_cidr" {
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC CIDR"
+}
+
+output "vpc_publics_subnet_arns" {
+  value       = module.vpc.public_subnet_arns
+  description = "VPC 퍼블릭 서비스 ARN"
+}
+
+output "vpc_public_subnets_cidr_blocks" {
+  value       = module.vpc.public_subnets_cidr_blocks
+  description = "VPC 퍼블릭 서비스 CIDR"
+}
+
+output "vpc_private_subnet_arns" {
+  value       = module.vpc.private_subnet_arns
+  description = "VPC 프라이빗 서비스 ARN"
+}
+
+output "vpc_private_subnets_cidr_blocks" {
+  value       = module.vpc.private_subnets_cidr_blocks
+  description = "VPC 프라이빗 서비스 CIDR"
+}
+
+output "nat_eni_private_ip" {
+  value       = module.nat.eni_private_ip
+  description = "NAT 인스턴스 private_ip"
+}
+
+output "ec2_private_ip" {
+  value       = module.ec2.private_ip
+  description = "EC2 프라이빗 ip"
+}

--- a/terraform/scenario/00.1-tier-ec2/variables.tf
+++ b/terraform/scenario/00.1-tier-ec2/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  default     = "ap-northeast-2"
+  description = "AWS 리전"
+}
+
+variable "name" {
+  default     = "1-tier-ec2"
+  description = "AWS 리전"
+}
+
+variable "vpc_cidr" {
+  default     = "10.0.0.0/16"
+  description = "VPC CIDR"
+}
+
+variable "environment" {
+  default     = "dev"
+  description = "dev/stg/prod"
+  validation {
+    condition     = contains(["dev", "stg", "prod"], var.environment)
+    error_message = "dev/stg/prod 환경이 아님"
+  }
+}

--- a/terraform/scenario/00.1-tier-ec2/versions.tf
+++ b/terraform/scenario/00.1-tier-ec2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  # required_version = ">= 1.0"
+
+  # required_providers {
+  #   aws = {
+  #     source  = "hashicorp/aws"
+  #     version = ">= 5.46"
+  #   }
+  # }
+}


### PR DESCRIPTION
AWS 상에 싱글 ec2 인스턴스 배포

1. SSM을 이용해서 터미널 접속
2. VPC를 구성하고 퍼블릭/프라이빗 서브넷을 구성한다. (인터넷게이트웨이, 라우팅테이블, NAT 인스턴스 구현)